### PR TITLE
Automatically upsert cron workloads

### DIFF
--- a/lib/gouda.rb
+++ b/lib/gouda.rb
@@ -46,7 +46,7 @@ module Gouda
   end
 
   def self.start
-    Gouda::Scheduler.update_scheduled_workloads!
+    Gouda::Scheduler.upsert_workloads_from_entries_list!
 
     queue_constraint = if ENV["GOUDA_QUEUES"]
       Gouda.parse_queue_constraint(ENV["GOUDA_QUEUES"])

--- a/lib/gouda/railtie.rb
+++ b/lib/gouda/railtie.rb
@@ -34,8 +34,6 @@ module Gouda
     # The `to_prepare` block which is executed once in production
     # and before each request in development.
     config.to_prepare do
-      Gouda::Scheduler.update_schedule_from_config!
-
       if defined?(Rails) && Rails.respond_to?(:application)
         config_from_rails = Rails.application.config.try(:gouda)
         if config_from_rails
@@ -52,6 +50,9 @@ module Gouda
         Gouda.config.polling_sleep_interval_seconds = 0.2
         Gouda.config.logger.level = Gouda.config.log_level
       end
+
+      Gouda::Scheduler.build_scheduler_entries_list!
+      Gouda::Scheduler.upsert_workloads_from_entries_list!
     end
   end
 end

--- a/test/gouda/scheduler_test.rb
+++ b/test/gouda/scheduler_test.rb
@@ -44,8 +44,8 @@ class GoudaSchedulerTest < ActiveSupport::TestCase
     }
 
     assert_nothing_raised do
-      Gouda::Scheduler.update_schedule_from_config!(tab)
-      Gouda::Scheduler.update_scheduled_workloads!
+      Gouda::Scheduler.build_scheduler_entries_list!(tab)
+      Gouda::Scheduler.upsert_workloads_from_entries_list!
     end
 
     assert_equal 1, Gouda::Workload.enqueued.count
@@ -67,12 +67,12 @@ class GoudaSchedulerTest < ActiveSupport::TestCase
     }
 
     assert_nothing_raised do
-      Gouda::Scheduler.update_schedule_from_config!(tab)
+      Gouda::Scheduler.build_scheduler_entries_list!(tab)
     end
 
     assert_changes_by(-> { Gouda::Workload.count }, exactly: 1) do
       3.times do
-        Gouda::Scheduler.update_scheduled_workloads!
+        Gouda::Scheduler.upsert_workloads_from_entries_list!
       end
     end
 
@@ -85,7 +85,7 @@ class GoudaSchedulerTest < ActiveSupport::TestCase
 
     assert_changes_by(-> { Gouda::Workload.count }, exactly: 1) do
       3.times do
-        Gouda::Scheduler.update_scheduled_workloads!
+        Gouda::Scheduler.upsert_workloads_from_entries_list!
       end
     end
 
@@ -111,11 +111,11 @@ class GoudaSchedulerTest < ActiveSupport::TestCase
     }
 
     assert_nothing_raised do
-      Gouda::Scheduler.update_schedule_from_config!(tab)
+      Gouda::Scheduler.build_scheduler_entries_list!(tab)
     end
 
     assert_changes_by(-> { Gouda::Workload.count }, exactly: 1) do
-      Gouda::Scheduler.update_scheduled_workloads!
+      Gouda::Scheduler.upsert_workloads_from_entries_list!
     end
 
     assert_equal [nil, nil], Gouda::Workload.first.serialized_params["arguments"]
@@ -149,13 +149,13 @@ class GoudaSchedulerTest < ActiveSupport::TestCase
       }
     }
     assert_nothing_raised do
-      Gouda::Scheduler.update_schedule_from_config!(tab)
+      Gouda::Scheduler.build_scheduler_entries_list!(tab)
     end
 
     travel_to Time.utc(2023, 6, 23, 20, 0)
     assert_changes_by(-> { Gouda::Workload.count }, exactly: 4) do
       3.times do
-        Gouda::Scheduler.update_scheduled_workloads!
+        Gouda::Scheduler.upsert_workloads_from_entries_list!
       end
     end
 
@@ -165,15 +165,15 @@ class GoudaSchedulerTest < ActiveSupport::TestCase
       kwargs: {mandatory: "good"}
     }
 
-    Gouda::Scheduler.update_schedule_from_config!(tab)
+    Gouda::Scheduler.build_scheduler_entries_list!(tab)
     assert_changes_by(-> { Gouda::Workload.count }, exactly: 1) do
-      Gouda::Scheduler.update_scheduled_workloads!
+      Gouda::Scheduler.upsert_workloads_from_entries_list!
     end
 
     assert tab.delete(:fifth)
-    Gouda::Scheduler.update_schedule_from_config!(tab)
+    Gouda::Scheduler.build_scheduler_entries_list!(tab)
     assert_changes_by(-> { Gouda::Workload.count }, exactly: -1) do
-      Gouda::Scheduler.update_scheduled_workloads!
+      Gouda::Scheduler.upsert_workloads_from_entries_list!
     end
 
     Gouda::Workload.all.each(&:perform_and_update_state!)


### PR DESCRIPTION
and document (and rename for clarity) the methods which work with the list of scheduler entries. It was previously not really clear that one method would not do anything to the database and another method would. It is better to be descriptive in that regard