### PR TITLE
Include tests in gem distribution

### DIFF
--- a/gouda.gemspec
+++ b/gouda.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/cheddar-me/gouda/CHANGELOG.md"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+    `git ls-files -z`.split("\x0")
   end
 
   spec.add_dependency "activerecord", "~> 7"


### PR DESCRIPTION
If someone needs to debug Gouda it helps that they won't have to look for the exact revision on GH to get the tests. And there is no sizable test corpus needed for Gouda (tests are usually excluded because of the large-ish files which are not necessary). Including tests lowers the barrier for new contributors.