### PR TITLE
Only enforce scheduler_key unique index on first execution

### DIFF
--- a/lib/gouda.rb
+++ b/lib/gouda.rb
@@ -100,7 +100,7 @@ module Gouda
     active_record_schema.add_index :gouda_workloads, [:priority, :id, :scheduled_at], where: "state = 'enqueued'", name: :gouda_checkout_all_index
     active_record_schema.add_index :gouda_workloads, [:id, :last_execution_heartbeat_at], where: "state = 'executing'", name: :gouda_last_heartbeat_index
     active_record_schema.add_index :gouda_workloads, [:enqueue_concurrency_key], where: "state = 'enqueued' AND enqueue_concurrency_key IS NOT NULL", unique: true, name: :guard_double_enqueue
-    active_record_schema.add_index :gouda_workloads, [:scheduler_key], where: "state = 'enqueued' AND scheduler_key IS NOT NULL", unique: true, name: :guard_double_schedule
+    active_record_schema.add_index :gouda_workloads, [:scheduler_key], where: "state = 'enqueued' AND scheduler_key IS NOT NULL AND (serialized_params->'executions')::int = 0", unique: true, name: :guard_double_schedule
     active_record_schema.add_index :gouda_workloads, [:execution_concurrency_key], where: "state = 'executing' AND execution_concurrency_key IS NOT NULL", unique: true, name: :guard_double_exec
     active_record_schema.add_index :gouda_workloads, [:active_job_id], name: :same_job_display_idx
     active_record_schema.add_index :gouda_workloads, [:priority], order: {priority: "ASC NULLS LAST"}, name: :ordered_priority_idx

--- a/lib/gouda.rb
+++ b/lib/gouda.rb
@@ -100,7 +100,7 @@ module Gouda
     active_record_schema.add_index :gouda_workloads, [:priority, :id, :scheduled_at], where: "state = 'enqueued'", name: :gouda_checkout_all_index
     active_record_schema.add_index :gouda_workloads, [:id, :last_execution_heartbeat_at], where: "state = 'executing'", name: :gouda_last_heartbeat_index
     active_record_schema.add_index :gouda_workloads, [:enqueue_concurrency_key], where: "state = 'enqueued' AND enqueue_concurrency_key IS NOT NULL", unique: true, name: :guard_double_enqueue
-    active_record_schema.add_index :gouda_workloads, [:scheduler_key], where: "state = 'enqueued' AND scheduler_key IS NOT NULL AND (serialized_params->'executions')::int = 0", unique: true, name: :guard_double_schedule
+    active_record_schema.add_index :gouda_workloads, [:scheduler_key], where: "state = 'enqueued' AND scheduler_key IS NOT NULL", unique: true, name: :guard_double_schedule
     active_record_schema.add_index :gouda_workloads, [:execution_concurrency_key], where: "state = 'executing' AND execution_concurrency_key IS NOT NULL", unique: true, name: :guard_double_exec
     active_record_schema.add_index :gouda_workloads, [:active_job_id], name: :same_job_display_idx
     active_record_schema.add_index :gouda_workloads, [:priority], order: {priority: "ASC NULLS LAST"}, name: :ordered_priority_idx

--- a/lib/gouda/adapter.rb
+++ b/lib/gouda/adapter.rb
@@ -57,10 +57,11 @@ class Gouda::Adapter
       # We can't tell Postgres to ignore conflicts on _both_ the scheduler key and the enqueue concurrency key but not on
       # the ID - it is either "all indexes" or "just one", but never "this index and that index". MERGE https://www.postgresql.org/docs/current/sql-merge.html
       # is in theory capable of solving this but let's not complicate things all to hastily, the hour is getting late
+      scheduler_key = active_job.try(:executions) == 0 ? active_job.scheduler_key : nil # only enforce scheduler key on first workload
       {
         active_job_id: active_job.job_id, # Multiple jobs can have the same ID due to retries, job-iteration etc.
         scheduled_at: active_job.scheduled_at || t_now,
-        scheduler_key: active_job.scheduler_key, # So that the scheduler_key gets retained between retries
+        scheduler_key: scheduler_key,
         priority: active_job.priority,
         execution_concurrency_key: extract_execution_concurrency_key(active_job),
         enqueue_concurrency_key: extract_enqueue_concurrency_key(active_job),

--- a/test/gouda/scheduler_test.rb
+++ b/test/gouda/scheduler_test.rb
@@ -71,8 +71,9 @@ class GoudaSchedulerTest < ActiveSupport::TestCase
     sleep(2)
     Gouda::Workload.checkout_and_perform_one(executing_on: "Unit test")
 
-    assert Gouda::Workload.retried.reload.count == 1
+    assert_equal 1, Gouda::Workload.retried.reload.count
     assert_nil Gouda::Workload.retried.first.scheduler_key
+    assert_equal "enqueued", Gouda::Workload.retried.first.state
   end
 
   test "re-inserts the next subsequent job after executing the queued one" do


### PR DESCRIPTION
Currently if a job is periodically scheduled but also long running (through multiple workloads), part of it's execution gets skipped. This is because we currently have a unique index on the scheduler_key, which gets copied over to subsequent workload. This means that if the next scheduled job is already enqueued (no matter how far in the future), any new workload from the currently executing job gets swallowed by the conflict on the unique index.

This is particularly an issue when using [job-iteration](https://github.com/Shopify/job-iteration) which relies on interrupting and re-enqueueing many workloads for the same active job (over a long period of time)

The proposed change is to change the unique index to only affect workloads where the executions count is 0. This is acceptable because jobs will still respect execution_concurrency_key and enqueue_concurrency_key unique indexes. Retry policies can also be configured on the jobs themselves if needed.