### PR TITLE
Remove logger overrides from Gouda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,50 @@
 ## [Unreleased]
 
-## [0.1.0] - 2023-06-10
+## [0.1.0] - 2024-06-10
 
 - Initial release
 
-## [0.1.1] - 2023-06-10
+## [0.1.1] - 2024-06-10
 
 - Fix support for older ruby versions until 2.7
 
-## [0.1.2] - 2023-06-11
+## [0.1.2] - 2024-06-11
 
 - Updated readme and method renaming in Scheduler
 
-## [0.1.3] - 2023-06-11
+## [0.1.3] - 2024-06-11
 
 - Allow the Rails app to boot even if there is no database yet
 
-## [0.1.4] - 2023-06-14
+## [0.1.4] - 2024-06-14
 
 - Rescue NoDatabaseError at scheduler update.
 - Include tests in gem, for sake of easier debugging.
 - Reduce logging in local test runs.
 - Bump local ruby version to 3.3.3
 
-## [0.1.5] - 2023-06-18
+## [0.1.5] - 2024-06-18
 
 - Update documentation
 - Don't pass on scheduler keys to retries
 
-## [0.1.6] - 2023-06-18
+## [0.1.6] - 2024-06-18
 
 - Fix: don't upsert workloads twice when starting Gouda.
 - Add back in Appsignal calls
 
-## [0.1.7] - 2023-06-21
+## [0.1.7] - 2024-06-21
 
 - Separate all instrumentation to use ActiveSupport::Notification
 
-## [0.1.8] - 2023-06-21
+## [0.1.8] - 2024-06-21
 
 - Move some missed instrumentations to Gouda.instrument
 
-## [0.1.9] - 2023-06-26
+## [0.1.9] - 2024-06-26
 
 - Fix: cleanup_preserved_jobs_before in Gouda::Workload.prune now points to Gouda.config
+
+## [0.1.10] - 2024-07-03
+
+- Fix: remove logger overrides that Gouda should install, as this causes problems for Rails apps hosting Gouda

--- a/lib/gouda/version.rb
+++ b/lib/gouda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gouda
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end

--- a/test/gouda/test_helper.rb
+++ b/test/gouda/test_helper.rb
@@ -23,8 +23,7 @@ class ActiveSupport::TestCase
     @adapter || Gouda::Adapter.new
     @case_random = Random.new(Minitest.seed)
     Gouda::Railtie.initializers.each(&:run)
-    ActiveJob::Base.logger = nil
-    Gouda.config.logger.level = 4
+    Gouda.logger.level = Logger::WARN
   end
 
   teardown do


### PR DESCRIPTION
In our app, this causes more trouble than it is worth - Gouda should use the common Rails logger and not touch it. If we want to log less SQL from the Gouda worker, we should look for a different way to do so - for example, by selectively silencing the logger using blocks or by temporarily lowering the logging level during the query.