### PR TITLE
Remove logger calls from to_prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,7 @@
 ## [0.1.10] - 2024-07-03
 
 - Fix: remove logger overrides that Gouda should install, as this causes problems for Rails apps hosting Gouda
+
+## [0.1.11] - 2024-07-03
+
+- Fix: make sure the Gouda logger config does not get used during Rails initialization

--- a/lib/gouda/railtie.rb
+++ b/lib/gouda/railtie.rb
@@ -43,14 +43,10 @@ module Gouda
           Gouda.config.preserve_job_records = config_from_rails[:preserve_job_records]
           Gouda.config.polling_sleep_interval_seconds = config_from_rails[:polling_sleep_interval_seconds]
           Gouda.config.worker_thread_count = config_from_rails[:worker_thread_count]
-          if Gouda.config.logger
-            Gouda.config.logger.level = config_from_rails[:log_level] || Gouda.config.log_level
-          end
         end
       else
         Gouda.config.preserve_job_records = false
         Gouda.config.polling_sleep_interval_seconds = 0.2
-        Gouda.config.logger.level = Gouda.config.log_level
       end
 
       Gouda::Scheduler.build_scheduler_entries_list!

--- a/lib/gouda/version.rb
+++ b/lib/gouda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gouda
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end


### PR DESCRIPTION
We do not test `to_prepare` in our test flow, as it turns out - and we were still assigning the value