### PR TITLE
Do not execute removed cron workloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7'
-          - '3.3'
+          - '3.1'
     services:
       postgres:
         image: postgres

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,43 @@
 ## [Unreleased]
 
-## [0.1.0] - 2024-06-10
 
-- Initial release
+## [0.1.13] - 2024-09-03
 
-## [0.1.1] - 2024-06-10
+- Ensure we won't execute workloads which were scheduled but are no longer present in the cron table entries.
 
-- Fix support for older ruby versions until 2.7
+## [0.1.12] - 2024-07-03
 
-## [0.1.2] - 2024-06-11
+- When doing polling, suppress DEBUG-level messages. This will stop Gouda spamming the logs with SQL in dev/test environments.
 
-- Updated readme and method renaming in Scheduler
+## [0.1.11] - 2024-07-03
 
-## [0.1.3] - 2024-06-11
+- Fix: make sure the Gouda logger config does not get used during Rails initialization
 
-- Allow the Rails app to boot even if there is no database yet
+## [0.1.10] - 2024-07-03
+
+- Fix: remove logger overrides that Gouda should install, as this causes problems for Rails apps hosting Gouda
+
+## [0.1.9] - 2024-06-26
+
+- Fix: cleanup_preserved_jobs_before in Gouda::Workload.prune now points to Gouda.config
+
+## [0.1.8] - 2024-06-21
+
+- Move some missed instrumentations to Gouda.instrument
+
+## [0.1.7] - 2024-06-21
+
+- Separate all instrumentation to use ActiveSupport::Notification
+
+## [0.1.6] - 2024-06-18
+
+- Fix: don't upsert workloads twice when starting Gouda.
+- Add back in Appsignal calls
+
+## [0.1.5] - 2024-06-18
+
+- Update documentation
+- Don't pass on scheduler keys to retries
 
 ## [0.1.4] - 2024-06-14
 
@@ -23,36 +46,19 @@
 - Reduce logging in local test runs.
 - Bump local ruby version to 3.3.3
 
-## [0.1.5] - 2024-06-18
+## [0.1.3] - 2024-06-11
 
-- Update documentation
-- Don't pass on scheduler keys to retries
+- Allow the Rails app to boot even if there is no database yet
 
-## [0.1.6] - 2024-06-18
+## [0.1.2] - 2024-06-11
 
-- Fix: don't upsert workloads twice when starting Gouda.
-- Add back in Appsignal calls
+- Updated readme and method renaming in Scheduler
 
-## [0.1.7] - 2024-06-21
+## [0.1.1] - 2024-06-10
 
-- Separate all instrumentation to use ActiveSupport::Notification
+- Fix support for older ruby versions until 2.7
 
-## [0.1.8] - 2024-06-21
+## [0.1.0] - 2024-06-10
 
-- Move some missed instrumentations to Gouda.instrument
+- Initial release
 
-## [0.1.9] - 2024-06-26
-
-- Fix: cleanup_preserved_jobs_before in Gouda::Workload.prune now points to Gouda.config
-
-## [0.1.10] - 2024-07-03
-
-- Fix: remove logger overrides that Gouda should install, as this causes problems for Rails apps hosting Gouda
-
-## [0.1.11] - 2024-07-03
-
-- Fix: make sure the Gouda logger config does not get used during Rails initialization
-
-## [0.1.12] - 2024-07-03
-
-- When doing polling, suppress DEBUG-level messages. This will stop Gouda spamming the logs with SQL in dev/test environments.

--- a/gouda.gemspec
+++ b/gouda.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = ["sebastian@cheddar.me", "me@julik.nl"]
   spec.homepage = "https://github.com/cheddar-me/gouda"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   spec.require_paths = ["lib"]
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/gouda.gemspec
+++ b/gouda.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
   spec.require_paths = ["lib"]
 
-  spec.metadata["homepage_uri"] = 
+  spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/cheddar-me/gouda/CHANGELOG.md"
 

--- a/lib/gouda.rb
+++ b/lib/gouda.rb
@@ -64,10 +64,8 @@ module Gouda
   def self.logger
     # By default, return a logger that sends data nowhere. The `Rails.logger` method
     # only becomes available later in the Rails lifecycle.
-    @fallback_gouda_logger ||= begin
-      ActiveSupport::Logger.new($stdout).tap do |logger|
-        logger.level = Logger::WARN
-      end
+    @fallback_gouda_logger ||= ActiveSupport::Logger.new($stdout).tap do |logger|
+      logger.level = Logger::WARN
     end
 
     # We want the Rails-configured loggers to take precedence over ours, since Gouda
@@ -81,22 +79,22 @@ module Gouda
     Rails.try(:logger) || ActiveJob::Base.try(:logger) || @fallback_gouda_logger
   end
 
-  def self.suppressing_sql_logs(&blk)
+  def self.suppressing_sql_logs(&)
     # This is used for frequently-called methods that poll the DB. If logging is done at a low level (DEBUG)
     # those methods print a lot of SQL into the logs, on every poll. While that is useful if
     # you collect SQL queries from the logs, in most cases - especially if this is used
     # in a side-thread inside Puma - the output might be quite annoying. So silence the
     # logger when we poll, but just to INFO. Omitting DEBUG-level messages gets rid of the SQL.
     if Gouda::Workload.logger
-      Gouda::Workload.logger.silence(Logger::INFO, &blk)
+      Gouda::Workload.logger.silence(Logger::INFO, &)
     else
       # In tests (and at earlier stages of the Rails boot cycle) the global ActiveRecord logger may be nil
       yield
     end
   end
 
-  def self.instrument(channel, options, &block)
-    ActiveSupport::Notifications.instrument("#{channel}.gouda", options, &block)
+  def self.instrument(channel, options, &)
+    ActiveSupport::Notifications.instrument("#{channel}.gouda", options, &)
   end
 
   def self.create_tables(active_record_schema)

--- a/lib/gouda/adapter.rb
+++ b/lib/gouda/adapter.rb
@@ -57,7 +57,7 @@ class Gouda::Adapter
       # We can't tell Postgres to ignore conflicts on _both_ the scheduler key and the enqueue concurrency key but not on
       # the ID - it is either "all indexes" or "just one", but never "this index and that index". MERGE https://www.postgresql.org/docs/current/sql-merge.html
       # is in theory capable of solving this but let's not complicate things all to hastily, the hour is getting late
-      scheduler_key = active_job.try(:executions) == 0 ? active_job.scheduler_key : nil # only enforce scheduler key on first workload
+      scheduler_key = (active_job.try(:executions) == 0) ? active_job.scheduler_key : nil # only enforce scheduler key on first workload
       {
         active_job_id: active_job.job_id, # Multiple jobs can have the same ID due to retries, job-iteration etc.
         scheduled_at: active_job.scheduled_at || t_now,

--- a/lib/gouda/version.rb
+++ b/lib/gouda/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gouda
-  VERSION = "0.1.12"
+  VERSION = "0.1.13"
 end

--- a/test/gouda/test_helper.rb
+++ b/test/gouda/test_helper.rb
@@ -58,14 +58,14 @@ class ActiveSupport::TestCase
 
   def subscribed_notification_for(notification)
     payload = nil
-    subscription = ActiveSupport::Notifications.subscribe notification do |name, start, finish, id, _payload|
-      payload = _payload
+    subscription = ActiveSupport::Notifications.subscribe notification do |name, start, finish, id, local_payload|
+      payload = local_payload
     end
 
     yield
 
     ActiveSupport::Notifications.unsubscribe(subscription)
 
-    return payload
+    payload
   end
 end

--- a/test/gouda/test_helper.rb
+++ b/test/gouda/test_helper.rb
@@ -56,17 +56,6 @@ class ActiveSupport::TestCase
     ActiveRecord::Base.connection.execute("TRUNCATE TABLE gouda_job_fuses")
   end
 
-  def test_create_tables
-    ActiveRecord::Base.transaction do
-      ActiveRecord::Base.connection.execute("DROP TABLE gouda_workloads")
-      ActiveRecord::Base.connection.execute("DROP TABLE gouda_job_fuses")
-      # The adapter has to be in a variable as the schema definition is scoped to the migrator, not self
-      ActiveRecord::Schema.define(version: 1) do |via_definer|
-        Gouda.create_tables(via_definer)
-      end
-    end
-  end
-
   def subscribed_notification_for(notification)
     payload = nil
     subscription = ActiveSupport::Notifications.subscribe notification do |name, start, finish, id, _payload|


### PR DESCRIPTION
We need to check whether a workload was enqueued with a scheduler key, but no longer is in the cron table. If that is the case (we are trying to execute a workload which has a scheduler key, but the scheduler does not know about that key) it means that the workload has been removed from the cron table and must not run. Moreover: running it can be dangerous because it was likely removed from the table for a reason. Should that be the case, mark the job "finished" and return `nil` to get to the next poll. If the deployed worker still has the workload in its scheduler table, but a new deploy removed it - this is a race condition, but we are willing to accept it.

Note that we are already "just not enqueueing" that job when the cron table gets loaded - but it is not enough.
If our system can be in a state of partial deployment:

```
  [  release 1 does have some_job_hourly crontab entry ]
                 [  release 2 no longer does                           ]
                 ^ --- race conditions possible here --^
```

...and  we remove the crontabled workloads during app boot, it does not give us a guarantee that release 1 won't reenqueue them. For example, via the "reinsert next scheduled" feature when the job is executing. This is why this safeguard is needed.

This protects us from a very dangerous failure mode where we would remove an entry from the cron table, deploy the change, and then still have the workload run a day later.