### PR TITLE
Fold all conditions into the pending workload query

### DIFF
--- a/lib/gouda/workload.rb
+++ b/lib/gouda/workload.rb
@@ -26,15 +26,38 @@ class Gouda::Workload < ActiveRecord::Base
   # The scope can be used to call `count()` to obtain the queue depth, which can
   # be employed as a driving metric for autoscaling.
   scope :waiting_to_start, ->(queue_constraint: Gouda::AnyQueue) {
+    # Check whether this workload was enqueued with a scheduler key, but no longer is in the cron table.
+    # If that is the case (we are trying to execute a workload which has a scheduler key, but the scheduler
+    # does not know about that key) it means that the workload has been removed from the cron table and must not run.
+    # Moreover: running it can be dangerous because it was likely removed from the table for a reason.
+    # Should that be the case, mark the job "finished" and return `nil` to get to the next poll. If the deployed worker still has
+    # the workload in its scheduler table, but a new deploy removed it - this is a race condition, but we are willing to accept it.
+    # Note that we are already "just not enqueueing" that job when the cron table gets loaded - this already happens.
+    #
+    # Removing jobs from the queue forcibly when we load the cron table is nice, but not enough, because our system can be in a state
+    # of partial deployment:
+    #
+    #   [  release 1 does have some_job_hourly crontab entry ]
+    #                  [  release 2 no longer does                           ]
+    #                  ^ --- race conditions possible here --^
+    #
+    # So even if we remove the crontabled workloads during app boot, it does not give us a guarantee
+    # that release 1 won't reinsert them.
+    # This is why this safeguard is needed.
     known_scheduler_keys = [nil] + Gouda::Scheduler.known_scheduler_keys.to_a
-    known_scheduler_keys_condition = known_scheduler_keys.map {|key| connection.quote(key) }.join(", ")
+    known_scheduler_keys_condition = known_scheduler_keys.map { |key| connection.quote(key) }.join(", ")
     condition_for_ready_to_execute_jobs = <<~SQL
       #{queue_constraint.to_sql}
-      AND execution_concurrency_key NOT IN (
-        SELECT execution_concurrency_key FROM #{quoted_table_name} WHERE state = 'executing' AND execution_concurrency_key IS NOT NULL
+      AND NOT EXISTS (
+        SELECT NULL
+        FROM gouda_job_fuses
+        WHERE gouda_job_fuses.active_job_class_name = #{quoted_table_name}.active_job_class_name
       )
-      AND active_job_class_name NOT IN (
-        SELECT active_job_class_name FROM gouda_job_fuses
+      AND NOT EXISTS (
+        SELECT NULL
+        FROM #{quoted_table_name} AS currently_executing_workloads
+        WHERE currently_executing_workloads.state = 'executing'
+          AND currently_executing_workloads.execution_concurrency_key = #{quoted_table_name}.execution_concurrency_key
       )
       AND (scheduler_key IS NULL OR scheduler_key IN (#{known_scheduler_keys_condition}))
       AND state = 'enqueued'
@@ -99,20 +122,10 @@ class Gouda::Workload < ActiveRecord::Base
 
   # Lock the next workload and mark it as executing
   def self.checkout_and_lock_one(executing_on:, queue_constraint: Gouda::AnyQueue)
-    where_query = <<~SQL
-      #{queue_constraint.to_sql}
-      AND NOT EXISTS (
-        SELECT NULL
-        FROM #{quoted_table_name} AS concurrent
-        WHERE concurrent.state = 'executing'
-          AND concurrent.execution_concurrency_key = #{quoted_table_name}.execution_concurrency_key
-      )
-    SQL
     # Enter a txn just to mark this job as being executed "by us". This allows us to avoid any
     # locks during execution itself, including advisory locks
     workloads_rel = Gouda::Workload
       .waiting_to_start
-      .where(where_query)
       .order("#{quoted_table_name}.priority ASC NULLS LAST")
       .lock("FOR UPDATE SKIP LOCKED")
       .limit(1)
@@ -125,34 +138,9 @@ class Gouda::Workload < ActiveRecord::Base
           workload = Gouda.suppressing_sql_logs { workloads_rel.first } # Silence SQL output as this gets called very frequently
           return nil unless workload
 
-          if workload.scheduler_key && !Gouda::Scheduler.known_scheduler_keys.include?(workload.scheduler_key)
-            # Check whether this workload was enqueued with a scheduler key, but no longer is in the cron table.
-            # If that is the case (we are trying to execute a workload which has a scheduler key, but the scheduler
-            # does not know about that key) it means that the workload has been removed from the cron table and must not run.
-            # Moreover: running it can be dangerous because it was likely removed from the table for a reason.
-            # Should that be the case, mark the job "finished" and return `nil` to get to the next poll. If the deployed worker still has
-            # the workload in its scheduler table, but a new deploy removed it - this is a race condition, but we are willing to accept it.
-            # Note that we are already "just not enqueueing" that job when the cron table gets loaded - this already happens.
-            #
-            # Removing jobs from the queue forcibly when we load the cron table is nice, but not enough, because our system can be in a state
-            # of partial deployment:
-            #
-            #   [  release 1 does have some_job_hourly crontab entry ]
-            #                  [  release 2 no longer does                           ]
-            #                  ^ --- race conditions possible here --^
-            #
-            # So even if we remove the crontabled workloads during app boot, it does not give us a guarantee that release 1 won't reinsert them.
-            # This is why this safeguard is needed.
-            error = {class_name: "WorkloadSkippedError", message: "Skipped as scheduler_key was no longer in the cron table"}
-            workload.update!(state: "finished", error:)
-            # And return nil. This will cause a brief "sleep" in the polling routine since the caller may think there are no more workloads
-            # in the queue, but only for a brief moment.
-            nil
-          else
-            # Once we have verified this job is OK to execute
-            workload.update!(state: "executing", executing_on: executing_on, last_execution_heartbeat_at: Time.now.utc, execution_started_at: Time.now.utc)
-            workload
-          end
+          # Once we have verified this job is OK to execute
+          workload.update!(state: "executing", executing_on: executing_on, last_execution_heartbeat_at: Time.now.utc, execution_started_at: Time.now.utc)
+          workload
         rescue ActiveRecord::RecordNotUnique
           # It can happen that due to a race the `execution_concurrency_key NOT IN` does not capture
           # a job which _just_ entered the "executing" state, apparently after we do our SELECT. This will happen regardless


### PR DESCRIPTION
When we autoscale based on queue depth, and use scheduler keys and fuses, we want to take into account all the conditions. The idea has two benefits:

* We should have only 1 scope for selecting the next workload, without having it double. It should be sufficiently efficient to be usable in both contexts (autoscaler metric and dequeue)
* When we autoscale, the fuses should have effect on that autoscaling. If we fuse out 80% of the workloads, there is no point running 80% of compute allocated to those workloads in the anticipation that they are going to become needed once we de-fuse the workloads back in.

Same for scheduler keys - it is possible to know which scheduler keys are currently known to the system, and there is no reason removed scheduled workloads should still influence the autoscaler.

This is WIP, as we need a decent benchmark which allows us to tweak this scope/query with a realistic queue size matching our real-life setup.