### PR TITLE
Ensure Jobs do not hold database connections outside of queries

### DIFF
--- a/lib/gouda.rb
+++ b/lib/gouda.rb
@@ -25,6 +25,7 @@ module Gouda
     config_accessor(:polling_sleep_interval_seconds, default: 0.2)
     config_accessor(:worker_thread_count, default: 1)
     config_accessor(:app_executor)
+    config_accessor(:prevent_connection_hoarding, default: false)
     config_accessor(:cron, default: {})
     config_accessor(:enable_cron, default: true)
     # Deprecated logger configuration. This needs to be available in the
@@ -72,7 +73,7 @@ module Gouda
     # is just an ActiveJob adapter and the Workload is just an ActiveRecord, in the end.
     # So it should be up to the developer of the app, not to us, to set the logger up
     # and configure out. There are also gems such as "stackdriver" from Google which
-    # rather unceremonously overwrite the Rails logger with their own. If that happens,
+    # rather unceremoniously overwrite the Rails logger with their own. If that happens,
     # it is the choice of the user to do so - and we should honor that choice. Same for
     # the logging level - the Rails logger level must take precendence. Same for logger
     # broadcasts which get set up, for example, by the Rails console when you start it.

--- a/lib/gouda/connection_managed_executor.rb
+++ b/lib/gouda/connection_managed_executor.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Gouda
+  # ConnectionManagedExecutor wraps the Rails executor to implement Rails 7.2+ 
+  # connection management patterns. This prevents database connections from being
+  # held for the entire duration of job execution.
+  #
+  # The key insight is that job code often calls ActiveRecord::Base.connection
+  # directly, which checks out a permanent connection. This executor temporarily
+  # overrides that method during job execution to use per-query connections instead.
+  class ConnectionManagedExecutor
+    def initialize(base_executor)
+      @base_executor = base_executor
+    end
+
+    def wrap(&block)
+      @base_executor.wrap do
+        # Temporarily override ActiveRecord::Base.connection to prevent permanent checkout
+        if defined?(ActiveRecord::Base)
+          # Store the original connection method
+          original_connection_method = ActiveRecord::Base.method(:connection)
+          
+          # Override the connection method to use per-query connections
+          ActiveRecord::Base.define_singleton_method(:connection) do
+            # Use with_connection for per-query access instead of permanent checkout
+            connection_pool.with_connection do |conn|
+              conn
+            end
+          end
+          
+          begin
+            # Execute the job with connection override in place
+            block.call
+          ensure
+            # Always restore the original connection method
+            ActiveRecord::Base.define_singleton_method(:connection, original_connection_method)
+          end
+        else
+          # Fallback if ActiveRecord is not available
+          block.call
+        end
+      end
+    end
+
+    # Delegate any other methods to the base executor
+    def method_missing(method_name, *args, **kwargs, &block)
+      @base_executor.public_send(method_name, *args, **kwargs, &block)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      @base_executor.respond_to?(method_name, include_private) || super
+    end
+  end
+end 

--- a/test/gouda/connection_management_test.rb
+++ b/test/gouda/connection_management_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class ConnectionTestJob < ActiveJob::Base
+  def perform(sleep_duration = 2)
+    # Access database at start
+    ActiveRecord::Base.connection.execute("SELECT 'job started'")
+    
+    # Simulate long-running work
+    sleep(sleep_duration)
+    
+    # Access database at end
+    ActiveRecord::Base.connection.execute("SELECT 'job finished'")
+  end
+end
+
+class ConnectionManagementTest < ActiveSupport::TestCase
+  def setup
+    super
+    ActiveRecord::Base.connection_handler.clear_active_connections!
+    @adapter = Gouda::Adapter.new
+  end
+
+  def teardown
+    ActiveRecord::Base.connection_handler.clear_active_connections!
+    super
+  end
+
+  test "connections are not held during job execution sleep periods" do
+    # Enable connection management for this test
+    original_setting = Gouda.config.prevent_connection_hoarding
+    Gouda.config.prevent_connection_hoarding = true
+    Gouda::Railtie.initializers.find { |i| i.name == "gouda.configure_rails_initialization" }.run
+    
+    begin
+      # Create and enqueue a job that sleeps
+      job = ConnectionTestJob.new(1)
+      @adapter.enqueue(job)
+      workload = Gouda::Workload.last
+      
+      pool = ActiveRecord::Base.connection_pool
+      connection_held_during_sleep = false
+      
+      # Monitor connection pool in a separate thread
+      monitor_thread = Thread.new do
+        sleep(0.3) # Wait for job to start and access DB
+        connection_held_during_sleep = pool.stat[:busy] > 0
+      end
+      
+      # Execute the job
+      execution_thread = Thread.new do
+        Gouda.config.app_executor.wrap do
+          workload.perform_and_update_state!
+        end
+      end
+      
+      execution_thread.join
+      monitor_thread.join
+      
+      # Verify that connections were not held during the sleep period
+      refute connection_held_during_sleep, 
+             "Expected connections to be released during job sleep period, but they were held"
+    ensure
+      # Restore the original setting
+      Gouda.config.prevent_connection_hoarding = original_setting
+      Gouda::Railtie.initializers.find { |i| i.name == "gouda.configure_rails_initialization" }.run
+    end
+  end
+  
+  test "prevent_connection_hoarding configuration is disabled by default" do
+    # Verify that connection management is disabled by default for backwards compatibility
+    refute Gouda.config.prevent_connection_hoarding,
+           "Expected prevent_connection_hoarding to be disabled by default for backwards compatibility"
+           
+    # Verify that the plain executor is used when the setting is disabled (default)
+    refute_includes Gouda.config.app_executor.class.name, "ConnectionManagedExecutor",
+                   "Expected plain executor when prevent_connection_hoarding is false (default)"
+  end
+  
+  test "prevent_connection_hoarding can be enabled" do
+    # Temporarily enable the setting
+    original_setting = Gouda.config.prevent_connection_hoarding
+    Gouda.config.prevent_connection_hoarding = true
+    
+    # Re-run the railtie initializer to apply the change
+    Gouda::Railtie.initializers.find { |i| i.name == "gouda.configure_rails_initialization" }.run
+    
+    begin
+      # Verify that ConnectionManagedExecutor is used when enabled
+      assert_includes Gouda.config.app_executor.class.name, "ConnectionManagedExecutor",
+                     "Expected ConnectionManagedExecutor when prevent_connection_hoarding is true"
+    ensure
+      # Restore the original setting and re-initialize
+      Gouda.config.prevent_connection_hoarding = original_setting
+      Gouda::Railtie.initializers.find { |i| i.name == "gouda.configure_rails_initialization" }.run
+    end
+  end
+  
+  test "prevent_connection_hoarding can be disabled" do
+    # Temporarily disable the setting
+    original_setting = Gouda.config.prevent_connection_hoarding
+    Gouda.config.prevent_connection_hoarding = false
+    
+    # Re-run the railtie initializer to apply the change
+    Gouda::Railtie.initializers.find { |i| i.name == "gouda.configure_rails_initialization" }.run
+    
+    begin
+      # Verify that the plain executor is used when disabled
+      refute_includes Gouda.config.app_executor.class.name, "ConnectionManagedExecutor",
+                     "Expected plain executor when prevent_connection_hoarding is false"
+      
+      # In test environment, it should be ActiveSupport::Executor (the class)
+      # or Rails application executor if available
+      executor_is_plain = Gouda.config.app_executor == ActiveSupport::Executor ||
+                         Gouda.config.app_executor.class.name.include?("Executor")
+      
+      assert executor_is_plain,
+             "Expected plain Rails executor when prevent_connection_hoarding is false, got: #{Gouda.config.app_executor.class.name}"
+    ensure
+      # Restore the original setting and re-initialize
+      Gouda.config.prevent_connection_hoarding = original_setting
+      Gouda::Railtie.initializers.find { |i| i.name == "gouda.configure_rails_initialization" }.run
+    end
+  end
+end 


### PR DESCRIPTION
By overriding the ActiveRecord::Base.connection method to actually use with_connection instead so the application code stays intact